### PR TITLE
Publish previously published entity after update

### DIFF
--- a/src/contentful.js
+++ b/src/contentful.js
@@ -120,7 +120,12 @@ module.exports = {
         console.log(`updating ${entity.sys.type.toLowerCase()} ${link}`);
 
         await apiIsReady();
-        await entity.update();
+        const updatedEntity = await entity.update();
+
+        if (entity.isPublished() && !entity.isUpdated()) {
+            await apiIsReady();
+            await updatedEntity.publish();
+        }
     },
 
     getLocales: async function (space) {


### PR DESCRIPTION
Publish previously published entity after update. Fixes https://github.com/veu/mmct/issues/7.